### PR TITLE
Include default copy constructor for select classes

### DIFF
--- a/include/eXevent.h
+++ b/include/eXevent.h
@@ -47,6 +47,7 @@ class eXEvent
    public:
 
       eXEvent();
+      eXEvent(const eXEvent&) = default;
       eXEvent(starlightConstants::event &ev);
       ~eXEvent();
 

--- a/include/vector3.h
+++ b/include/vector3.h
@@ -43,6 +43,7 @@ class vector3
 {
    public:
       vector3();
+      vector3(const vector3&) = default;
       vector3(double *vec);
       vector3(double x, double y, double z);
       virtual ~vector3();


### PR DESCRIPTION
In gcc-10 the following error appears due to default setting `-Werror=deprecated-copy`:
```
In file included from /home/wdconinc/git/estarlight/include/starlightparticle.h:38,
                 from /home/wdconinc/git/estarlight/src/starlightparticle.cpp:34:
/home/wdconinc/git/estarlight/include/lorentzvector.h: In copy constructor ‘constexpr lorentzVector::lorentzVector(const lorentzVector&)’:
/home/wdconinc/git/estarlight/include/lorentzvector.h:42:7: error: implicitly-declared ‘constexpr vector3::vector3(const vector3&)’ is deprecated [-Werror=deprecated-copy]
   42 | class lorentzVector
      |       ^~~~~~~~~~~~~
In file included from /home/wdconinc/git/estarlight/include/lorentzvector.h:38,
                 from /home/wdconinc/git/estarlight/include/starlightparticle.h:38,
                 from /home/wdconinc/git/estarlight/src/starlightparticle.cpp:34:
/home/wdconinc/git/estarlight/include/vector3.h:55:15: note: because ‘vector3’ has user-provided ‘vector3& vector3::operator=(const vector3&)’
   55 |      vector3& operator =(const vector3& vec)
      |               ^~~~~~~~
In file included from /home/wdconinc/git/estarlight/src/starlightparticle.cpp:34:
/home/wdconinc/git/estarlight/include/starlightparticle.h: In member function ‘lorentzVector starlightParticle::getVertex() const’:
/home/wdconinc/git/estarlight/include/starlightparticle.h:75:48: note: synthesized method ‘constexpr lorentzVector::lorentzVector(const lorentzVector&)’ first required here
   75 |       lorentzVector getVertex() const { return _vertex; }
      |                                                ^~~~~~~
```

The error is fixed by defining the default copy constructor.