### PR TITLE
fix: allow for `make install` into CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,13 @@ add_custom_command (TARGET Starlib POST_BUILD COMMAND touch ARGS slight.txt)
 add_custom_command (TARGET Starlib POST_BUILD COMMAND cp ARGS slight.txt slight.txt.bak)
 add_custom_command (TARGET Starlib POST_BUILD COMMAND echo ARGS '' > slight.txt )
 
+# Installation of targets
+install(TARGETS e_starlight ${THIS_LIB}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
 
 message(STATUS "Cmake did not find any errors. run 'make' to build the project.")
 message(STATUS "On multi-core machines 'make -j#', where # is the number of parallel jobs, can speedup compilation considerably.")

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ cmake ~/the_path/estarlight
 ```
 (g)make
 ```
-  * The compilation will produce an executable to run: estarlight
+* The compilation will produce an executable to run: estarlight
+* Install the code to `CMAKE_INSTALL_PREFIX` (defaults to `/usr/local`)
+```
+(g)make install
+```
 
 * Set up the desired running conditions in the input file:
 ```

--- a/README.md
+++ b/README.md
@@ -131,3 +131,4 @@ To compile eSTARlight with HepMC3 output enabled, use:
 ```
 cmake /pathto/estarlight -DENABLE_HEPMC3=ON -DHepMC3_DIR=/pathto/hepmc3/hepmc3-install
 ```
+NOTE: running `make install` on your eSTARlight build when using HepMC3 may result in errors on some systems. If this is the case, it is recommended to not install eSTARlight when using HepMC3 and simply run the code from the build directory.


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Previously, no `install` target was defined due to the absence of `install` lines in the `CMakeLists.txt`. This adds the minimum of required lines to install the binaries and static library into the prefix.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators: added to README.md

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.