### PR TITLE
restore ion pdg for outgoing ion

### DIFF
--- a/src/hepmc3writer.cpp
+++ b/src/hepmc3writer.cpp
@@ -126,8 +126,7 @@ int hepMC3Writer::writeEvent(const eXEvent &event, int eventnumber)
                ion_lorentzVec.GetPz(),
                ion_lorentzVec.GetE());
 
-  //  PDG code for protons is 2212; not clear what to do for ions, but use proton ID for now  SRK August 8, 2021
-  HepMC3::GenParticlePtr hepmc3_ion = std::make_shared<HepMC3::GenParticle>( hepmc3_ion_four_vector, 2212, 1 );  
+  HepMC3::GenParticlePtr hepmc3_ion = std::make_shared<HepMC3::GenParticle>( hepmc3_ion_four_vector, targetBeam_pdg_id_, 1 );  
 
   hepmc3_ion_vertex_to_write->add_particle_out( hepmc3_ion );
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?

The PR restores ion pdgID instead of 2212 introduced in https://github.com/eic/estarlight/commit/bdca506a3f1ab4dc6c4dff336304e429905942ec, since `ddsim` is able now to handle ions (https://github.com/eic/epic/issues/355).

The old workaround created outgoing protons with 22.5 TeV kinetic energy (in case of ePb collisions at energy of 18x110), which interact with far-forward detectors resulting in 30 min / event simulation time. 

Running time of detector simulation (`ddsim`) with ions at final state is currently 3-5 min / event.

### What kind of change does this PR introduce?
-  Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
-  Changes have been communicated to collaborators

@SpencerKlein please confirm that the current fix is OK. 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no